### PR TITLE
Remove a mention TracePoint from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ And add `final` modifier to target method.
 
 ### for Production
 If you want to disable Finalist, write `Finalist.disable = true` at first line.
-If Finalist is disabled, TracePoint never runs, and so there is no overhead of VM instruction.
 
 ### Examples
 


### PR DESCRIPTION
Because finalist no longer depends on TracePoint.


I'm not sure other advantages of the disabled mode, so I just removed the line. If you have other advantages, I'll changes the line like `If Finalist is disabled, <the advantage>`.

(Disabled mode makes `include` and so on fast. But the improvement is very very small, so I think it is not an advantage.)